### PR TITLE
Surface exception details in Try* DAO methods

### DIFF
--- a/src/NosCore.Dao/Dao.cs
+++ b/src/NosCore.Dao/Dao.cs
@@ -76,7 +76,7 @@ namespace NosCore.Dao
             }
             catch (Exception e)
             {
-                _logger.Error("", e);
+                _logger.Error(e, "TryInsertOrUpdateAsync<{Entity}> failed", typeof(TEntity).Name);
                 return default!;
             }
         }
@@ -119,7 +119,7 @@ namespace NosCore.Dao
             }
             catch (Exception e)
             {
-                _logger.Error("", e);
+                _logger.Error(e, "TryInsertOrUpdateAsync<{Entity}> batch failed", typeof(TEntity).Name);
                 return false;
             }
         }
@@ -139,7 +139,7 @@ namespace NosCore.Dao
             }
             catch (Exception e)
             {
-                _logger.Error("", e);
+                _logger.Error(e, "TryDeleteAsync<{Entity}> batch failed", typeof(TEntity).Name);
                 return null;
             }
         }
@@ -169,7 +169,7 @@ namespace NosCore.Dao
             }
             catch (Exception e)
             {
-                _logger.Error(e.Message, e);
+                _logger.Error(e, "TryDeleteAsync<{Entity}> failed", typeof(TEntity).Name);
                 return default!;
             }
         }

--- a/src/NosCore.Dao/NosCore.Dao.csproj
+++ b/src/NosCore.Dao/NosCore.Dao.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/NosCoreIO/NosCore.Dao.git</RepositoryUrl>
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>nostale, noscore, nostale private server source, nostale emulator</PackageTags>
-    <Version>4.0.3</Version>
+    <Version>4.0.4</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>NosCore's Dao</Description>
     <PackageLicenseExpression></PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Replace `_logger.Error(\"\", e)` (empty template, exception as arg) with `_logger.Error(e, \"TryXxxAsync<{Entity}> failed\", ...)` — Serilog's proper exception-first signature
- Bump to 4.0.4

## Why
When a DAO swallows an exception today, the call logs an empty line and returns false/null. Downstream services see only the silent failure mode and have no way to diagnose schema / constraint / FK violations.

Example observed in the wild:
\`\`\`
EROR 17:12:33 --                                                    <- DAO's empty log
EROR 17:12:33 -- Save Character failed. SessionId: 14               <- caller's fallback
System.InvalidOperationException: ItemInstance batch insert failed
\`\`\`

After the fix the first line will carry the actual SQL/FK/validation error so the root cause is visible without instrumenting callers.

## Test plan
- [ ] Build
- [ ] Existing tests still pass
- [ ] Consume from a downstream server; provoke a DB failure (e.g. drop a FK) and verify the real exception + stack appear in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)