### PR TITLE
Filter TPH DTO candidates by 'Dto' suffix

### DIFF
--- a/src/NosCore.Dao/Dao.cs
+++ b/src/NosCore.Dao/Dao.cs
@@ -44,7 +44,13 @@ namespace NosCore.Dao
         /// <param name="dbContextBuilder">The database context factory</param>
         public Dao(ILogger logger, Func<DbContext> dbContextBuilder)
         {
-            var dtos = InterfaceHelper.GetAllTypesOf<TDto>().ToList();
+            // The DTO list is filtered to actual DTO classes (suffix "Dto") — otherwise
+            // downstream subclasses of a DTO (e.g. a runtime wrapper `WearableInstance :
+            // WearableInstanceDto`) also satisfy TrimEnd("Dto") == entity name and can be
+            // picked first, breaking later lookups keyed by the real DTO type.
+            var dtos = InterfaceHelper.GetAllTypesOf<TDto>()
+                .Where(s => s.Name.EndsWith("Dto"))
+                .ToList();
             _tphEntityToDtoDictionary = new ReadOnlyDictionary<Type, Type>(typeof(TDto).IsInterface ?
                 InterfaceHelper.GetAllTypesOf<TEntity>().ToDictionary(
                     entity => entity,

--- a/src/NosCore.Dao/NosCore.Dao.csproj
+++ b/src/NosCore.Dao/NosCore.Dao.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/NosCoreIO/NosCore.Dao.git</RepositoryUrl>
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>nostale, noscore, nostale private server source, nostale emulator</PackageTags>
-    <Version>4.0.4</Version>
+    <Version>4.0.5</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>NosCore's Dao</Description>
     <PackageLicenseExpression></PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Constrain the DTO candidate list in the TPH dictionary construction to types actually ending with \`Dto\`
- Fixes runtime \`KeyNotFoundException\` on save when a runtime wrapper class (e.g. NosCore's \`WearableInstance : WearableInstanceDto\`) collides with the real DTO in the name-match
- Bump to 4.0.5

## Why
\`GetAllTypesOf<TDto>\` returns every non-interface type assignable from the DTO interface, including runtime wrappers that live outside the Data assembly. When \`entity => dtos.First(s => s.Name.TrimEnd(\"Dto\") == entity.Name.TrimEnd(\"Entity\"))\` runs for an entity like \`WearableInstance\`, both \`WearableInstanceDto\` and the GameObject wrapper \`WearableInstance\` (whose name stripped of \`Dto\` is \`WearableInstance\`) match. First() picks whichever iteration order yields first, which in practice ended up being the wrapper — so the real DTO type is never registered.

\`ToEntity\` later walks the instance's base chain up to the first \`Dto\`-suffixed class and looks it up in the reverse dictionary. The DTO isn't there, \`Dictionary.get_Item\` throws, and consumers see a silent save failure (or, post-4.0.4, a properly-logged KeyNotFoundException).

## Test plan
- [x] \`dotnet test\` — all Dao tests pass
- [ ] Consume from NosCore world server; provoke a character save with a WearableInstance in inventory and verify it persists