### PR TITLE
chore: bump packages to latest

### DIFF
--- a/src/NosCore.Dao/NosCore.Dao.csproj
+++ b/src/NosCore.Dao/NosCore.Dao.csproj
@@ -29,11 +29,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mapster" Version="7.4.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.10" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Mapster" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.6" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/test/NosCore.Dao.Tests/NosCore.Dao.Tests.csproj
+++ b/test/NosCore.Dao.Tests/NosCore.Dao.Tests.csproj
@@ -5,7 +5,6 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -13,11 +12,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- `Mapster` 7.4.0 → 10.0.7 (major)
- `Microsoft.EntityFrameworkCore`/`.Relational`/`.Sqlite` 10.0.0 → 10.0.6
- `Microsoft.Extensions.DependencyModel` 9.0.10 → 10.0.6
- `Serilog` 4.3.0 → 4.3.1
- `Microsoft.NET.Test.Sdk` 18.0.1 → 18.4.0
- `MSTest.TestAdapter`/`MSTest.TestFramework` 4.0.2 → 4.2.1
- Drop `TestingPlatformDotnetTestSupport` opt-in (legacy VSTest runner under .NET 10 SDK works with MSTest 4.x)

All 58 tests pass locally. Supersedes the remaining Dependabot package PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)