### PR TITLE
feat!: replace Serilog.ILogger with Microsoft.Extensions.Logging.ILogger<T>

### DIFF
--- a/src/NosCore.Dao/Dao.cs
+++ b/src/NosCore.Dao/Dao.cs
@@ -15,9 +15,9 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Mapster;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NosCore.Dao.Extensions;
 using NosCore.Dao.Interfaces;
-using Serilog;
 
 namespace NosCore.Dao
 {
@@ -31,7 +31,7 @@ namespace NosCore.Dao
     where TEntity : class
     where TPk : struct
     {
-        private readonly ILogger _logger;
+        private readonly ILogger<Dao<TEntity, TDto, TPk>> _logger;
         private readonly PropertyInfo[] _primaryKey;
         private readonly Func<DbContext> _dbContextBuilder;
         private readonly ReadOnlyDictionary<Type, Type> _tphEntityToDtoDictionary;
@@ -42,7 +42,7 @@ namespace NosCore.Dao
         /// </summary>
         /// <param name="logger">The logger instance</param>
         /// <param name="dbContextBuilder">The database context factory</param>
-        public Dao(ILogger logger, Func<DbContext> dbContextBuilder)
+        public Dao(ILogger<Dao<TEntity, TDto, TPk>> logger, Func<DbContext> dbContextBuilder)
         {
             // The DTO list is filtered to actual DTO classes (suffix "Dto") — otherwise
             // downstream subclasses of a DTO (e.g. a runtime wrapper `WearableInstance :
@@ -95,7 +95,7 @@ namespace NosCore.Dao
             }
             catch (Exception e)
             {
-                _logger.Error(e, "TryInsertOrUpdateAsync<{Entity}> failed", typeof(TEntity).Name);
+                _logger.LogError(e, "TryInsertOrUpdateAsync<{Entity}> failed", typeof(TEntity).Name);
                 return default!;
             }
         }
@@ -139,7 +139,7 @@ namespace NosCore.Dao
             }
             catch (Exception e)
             {
-                _logger.Error(e, "TryInsertOrUpdateAsync<{Entity}> batch failed", typeof(TEntity).Name);
+                _logger.LogError(e, "TryInsertOrUpdateAsync<{Entity}> batch failed", typeof(TEntity).Name);
                 return false;
             }
         }
@@ -160,7 +160,7 @@ namespace NosCore.Dao
             }
             catch (Exception e)
             {
-                _logger.Error(e, "TryDeleteAsync<{Entity}> batch failed", typeof(TEntity).Name);
+                _logger.LogError(e, "TryDeleteAsync<{Entity}> batch failed", typeof(TEntity).Name);
                 return null;
             }
         }
@@ -191,7 +191,7 @@ namespace NosCore.Dao
             }
             catch (Exception e)
             {
-                _logger.Error(e, "TryDeleteAsync<{Entity}> failed", typeof(TEntity).Name);
+                _logger.LogError(e, "TryDeleteAsync<{Entity}> failed", typeof(TEntity).Name);
                 return default!;
             }
         }

--- a/src/NosCore.Dao/NosCore.Dao.csproj
+++ b/src/NosCore.Dao/NosCore.Dao.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/NosCoreIO/NosCore.Dao.git</RepositoryUrl>
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>nostale, noscore, nostale private server source, nostale emulator</PackageTags>
-    <Version>4.0.5</Version>
+    <Version>5.0.0</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>NosCore's Dao</Description>
     <PackageLicenseExpression></PackageLicenseExpression>
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.6" />
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/test/NosCore.Dao.Tests/CompositeEntityDaoTests.cs
+++ b/test/NosCore.Dao.Tests/CompositeEntityDaoTests.cs
@@ -12,7 +12,7 @@ using Moq;
 using NosCore.Dao.Tests.Database;
 using NosCore.Dao.Tests.Database.Entities.CompositeTphEntities;
 using NosCore.Dao.Tests.TestsModels.CompositeModels;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.Dao.Tests
 {
@@ -27,7 +27,7 @@ namespace NosCore.Dao.Tests
         {
             _dbContextBuilder = new DbContextBuilder();
             _dao =
-                new Dao<CompositeEntity, CompositeDto, (int, int)>(new Mock<ILogger>().Object, _dbContextBuilder.CreateContext);
+                new Dao<CompositeEntity, CompositeDto, (int, int)>(new Mock<ILogger<Dao<CompositeEntity, CompositeDto, (int, int)>>>().Object, _dbContextBuilder.CreateContext);
         }
 
         [TestMethod]

--- a/test/NosCore.Dao.Tests/CompositeTphEntityDaoTests.cs
+++ b/test/NosCore.Dao.Tests/CompositeTphEntityDaoTests.cs
@@ -13,7 +13,7 @@ using NosCore.Dao.Tests.Database;
 using NosCore.Dao.Tests.Database.Entities.CompositeEntities;
 using NosCore.Dao.Tests.Database.Entities.CompositeTphEntities;
 using NosCore.Dao.Tests.TestsModels.CompositeTphModels;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.Dao.Tests
 {
@@ -27,7 +27,7 @@ namespace NosCore.Dao.Tests
         public void Setup()
         {
             _dbContextBuilder = new DbContextBuilder();
-            _dao = new Dao<CompositeTphBaseEntity, ICompositeTphDto, (int, int)>(new Mock<ILogger>().Object, _dbContextBuilder.CreateContext);
+            _dao = new Dao<CompositeTphBaseEntity, ICompositeTphDto, (int, int)>(new Mock<ILogger<Dao<CompositeTphBaseEntity, ICompositeTphDto, (int, int)>>>().Object, _dbContextBuilder.CreateContext);
         }
 
         [TestMethod]

--- a/test/NosCore.Dao.Tests/InheritanceSimpleEntityDaoTests.cs
+++ b/test/NosCore.Dao.Tests/InheritanceSimpleEntityDaoTests.cs
@@ -12,7 +12,7 @@ using Moq;
 using NosCore.Dao.Tests.Database;
 using NosCore.Dao.Tests.Database.Entities.SimpleEntities;
 using NosCore.Dao.Tests.TestsModels.SimpleModels;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.Dao.Tests
 {
@@ -27,7 +27,7 @@ namespace NosCore.Dao.Tests
         {
             _dbContextBuilder = new DbContextBuilder();
             _dao =
-                new Dao<SimpleEntity, SimpleDto, int>(new Mock<ILogger>().Object, _dbContextBuilder.CreateContext);
+                new Dao<SimpleEntity, SimpleDto, int>(new Mock<ILogger<Dao<SimpleEntity, SimpleDto, int>>>().Object, _dbContextBuilder.CreateContext);
         }
 
         [TestMethod]

--- a/test/NosCore.Dao.Tests/SimpleEntityDaoTests.cs
+++ b/test/NosCore.Dao.Tests/SimpleEntityDaoTests.cs
@@ -12,7 +12,7 @@ using Moq;
 using NosCore.Dao.Tests.Database;
 using NosCore.Dao.Tests.Database.Entities.SimpleEntities;
 using NosCore.Dao.Tests.TestsModels.SimpleModels;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.Dao.Tests
 {
@@ -27,7 +27,7 @@ namespace NosCore.Dao.Tests
         {
             _dbContextBuilder = new DbContextBuilder();
             _dao =
-                new Dao<SimpleEntity, SimpleDto, int>(new Mock<ILogger>().Object, _dbContextBuilder.CreateContext);
+                new Dao<SimpleEntity, SimpleDto, int>(new Mock<ILogger<Dao<SimpleEntity, SimpleDto, int>>>().Object, _dbContextBuilder.CreateContext);
         }
 
         [TestMethod]

--- a/test/NosCore.Dao.Tests/SimpleWithFkEntityDaoTests.cs
+++ b/test/NosCore.Dao.Tests/SimpleWithFkEntityDaoTests.cs
@@ -14,7 +14,7 @@ using Moq;
 using NosCore.Dao.Tests.Database;
 using NosCore.Dao.Tests.Database.Entities.SimpleEntities;
 using NosCore.Dao.Tests.TestsModels.SimpleModels;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.Dao.Tests
 {
@@ -36,7 +36,7 @@ namespace NosCore.Dao.Tests
             });
             await init.SaveChangesAsync().ConfigureAwait(false);
             _dao =
-                new Dao<SimpleWithFkEntity, SimpleWithFkDto, int>(new Mock<ILogger>().Object, _dbContextBuilder);
+                new Dao<SimpleWithFkEntity, SimpleWithFkDto, int>(new Mock<ILogger<Dao<SimpleWithFkEntity, SimpleWithFkDto, int>>>().Object, _dbContextBuilder);
         }
 
         [TestMethod]

--- a/test/NosCore.Dao.Tests/TphEntityDaoTests.cs
+++ b/test/NosCore.Dao.Tests/TphEntityDaoTests.cs
@@ -12,7 +12,7 @@ using Moq;
 using NosCore.Dao.Tests.Database;
 using NosCore.Dao.Tests.Database.Entities.TphEntities;
 using NosCore.Dao.Tests.TestsModels.TphModels;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.Dao.Tests
 {
@@ -26,7 +26,7 @@ namespace NosCore.Dao.Tests
         public void Setup()
         {
             _dbContextBuilder = new DbContextBuilder();
-            _dao = new Dao<TphBaseEntity, ITphDto, int>(new Mock<ILogger>().Object, _dbContextBuilder.CreateContext);
+            _dao = new Dao<TphBaseEntity, ITphDto, int>(new Mock<ILogger<Dao<TphBaseEntity, ITphDto, int>>>().Object, _dbContextBuilder.CreateContext);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
- Dao ctor now takes `ILogger<Dao<TEntity, TDto, TPk>>` (Microsoft.Extensions.Logging) instead of `Serilog.ILogger`.
- `_logger.Error(...)` → `_logger.LogError(...)`.
- Drops the `Serilog` package ref in favor of `Microsoft.Extensions.Logging.Abstractions 10.0.6`.
- Version bumped to **5.0.0** (breaking change).

## Breaking change
Consumers that call `new Dao<TDb, TDto, TPk>(serilogLogger, ...)` must now pass an `ILogger<Dao<TDb, TDto, TPk>>` — typically resolved via DI. Serilog still works as the backend provider when wired through `UseSerilog()`.

## Test plan
- [x] `dotnet build -c Release` green (nupkg produced).
- [x] `dotnet test test/NosCore.Dao.Tests` — 58/58 passing.

Refs NosCoreIO/NosCore#1607.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging framework to Microsoft.Extensions.Logging as the standard library.
  * Bumped package version to 5.0.0 with updated dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->